### PR TITLE
fix redis-slave docker image

### DIFF
--- a/v1/redis-slave-deployment.yaml
+++ b/v1/redis-slave-deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: redis-slave
-        image: ibmcloudlabs/redis-slave:v3
+        image: ibmcom/guestbook-redis-slave:v2
         resources:
           requests:
             cpu: 100m

--- a/v2/redis-slave-deployment.yaml
+++ b/v2/redis-slave-deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: redis-slave
-        image: ibmcloudlabs/redis-slave:v3
+        image: ibmcom/guestbook-redis-slave:v2
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
* ibmcom側にredis-slaveのimageが登録されたためそちらを利用するように変更